### PR TITLE
Remove activity evolution percentages from baseline timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,14 @@ and peer reviews, but for a focused automation like Pixel Planner, vibe-coding w
   - The effective date is today, but if today is beyond the last milestone date (across all phases), it is clamped to that last milestone date.
 
 - Basis (which plan dates are used)
-  - `--basis current` (default): position bars and compute "should-be" from Current Plan dates.
-  - `--basis baseline`: use Baseline Plan dates instead.
+  - `--basis current` (default): position bars and compute "should-be" from Current Plan dates. Shows activity evolution percentages.
+  - `--basis baseline`: use Baseline Plan dates instead. Shows clean timeline bars without activity evolution percentages.
   - This separation allows you to maintain both your original baseline and revised current plans, enabling comparison between planned vs actual timeline evolution.
   - You can generate timelines using either version independently, making it easy to track scope changes and schedule adjustments over time.
 
 ## Percentages (progress logic)
+**Note: Activity evolution percentages are only shown for `--basis current` timelines. Baseline timelines show clean bars without percentages.**
+
 - Header percentages (global): `X% / Y%`
   - X% = executed/total across all milestones (executed = count of `Done`).
   - Y% = planned-by-effective-date/total across all milestones, based on the chosen basis.
@@ -110,7 +112,7 @@ and peer reviews, but for a focused automation like Pixel Planner, vibe-coding w
 
 - Important rule: "planned-by-effective-date" uses a strict comparison of planned date < effective date. Milestones due today are counted as should-be tomorrow (after the day passes).
 
-- Direction indicator: ▲ if executed ≥ should-be; otherwise ▼.
+- Direction indicator: ▲ if executed ≥ should-be; otherwise ▼ (for current timelines only).
 
 ## Milestone Status Overview
 When using `--include-status`, a status graph is generated showing milestone distribution:
@@ -126,11 +128,19 @@ When using `--include-status`, a status graph is generated showing milestone dis
 - Ready for Review : 01 → [■] 6%
 ```
 
-## Example timeline (snippet)
+## Example timelines
+
+### Current timeline (with activity evolution percentages)
 ```vb
                                                               ┌─→ 2025-03-02 (33% / 67%)
 - Phase 01 – Install Infrastructure ▲ W 05-08 2025-01-31 to 2025-02-20 → [■ ■ ■ ■] 50% / 100%
 - Phase 02 – Deploy new App ▼         W 09-09 2025-03-02 to 2025-03-02 →     |      [■] 0% / 0%
+```
+
+### Baseline timeline (clean bars without percentages)
+```text
+- Phase 01 – Install Infrastructure ▲ W 05-08 2025-01-31 to 2025-02-20 → [■ ■ ■ ■]
+- Phase 02 – Deploy new App ▲         W 09-09 2025-03-02 to 2025-03-02 →         [■]
 ```
 
 ## Tips and gotchas

--- a/scripts/pixel_planner.py
+++ b/scripts/pixel_planner.py
@@ -508,25 +508,12 @@ def generate_baseline_block(phases: List[Phase], plan_basis: str = "baseline") -
 
         bar = "".join(canvas)
 
-        # Per-phase actual vs should-be (for baseline, use all milestones as baseline context)
-        phase_total = len(phase.milestones)
-        phase_done = sum(1 for m in phase.milestones if m.status.strip().lower() == "done")
-        # For baseline: "should-be" is based on the baseline plan being the reference
-        phase_baseline_total = sum(1 for m in phase.milestones if m.baseline_plan is not None)
-
-        def pct(n: int, d: int) -> str:
-            if d <= 0:
-                return "0%"
-            return f"{(n / d) * 100.0:.0f}%"
-
         # Direction: for baseline view, always show ▲ (no time-based comparison)
         direction = "▲"
 
         left_prefix = left_prefix_text(phase, s, e, direction)
-        a_str = pct(phase_done, phase_total)
-        b_str = pct(phase_baseline_total, phase_total)
 
-        lines.append(f"{left_prefix}{bar} {a_str} / {b_str}")
+        lines.append(f"{left_prefix}{bar}")
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- Simplify baseline timeline display by removing activity evolution percentages (X% / Y%)
- Baseline timelines now show clean bars without progress indicators for cleaner reference display
- Current timelines continue to show activity evolution percentages as before

## Test plan
- [x] Test baseline timeline generation works without percentages
- [x] Test current timeline generation still shows percentages correctly
- [x] Update documentation with examples of both timeline types
- [x] Run type checking and linting to ensure code quality

🤖 Generated with [Claude Code](https://claude.ai/code)